### PR TITLE
Fix missing fields in booking details page. Fixes #52

### DIFF
--- a/opencabs/templates/opencabs/booking_details.html
+++ b/opencabs/templates/opencabs/booking_details.html
@@ -17,7 +17,7 @@
             <dd>{{  booking.humanized_payment_method }}</dd>
 
             <dt>Payment status</dt>
-            <dd>{{  booking.humanize_payment_status }}</dd>
+            <dd>{{  booking.humanized_payment_status }}</dd>
 
             <dt>Source<dt>
             <dd>{{ booking.source }}</dd>

--- a/opencabs/templates/opencabs/booking_details.html
+++ b/opencabs/templates/opencabs/booking_details.html
@@ -29,7 +29,7 @@
             <dd>{{ booking.get_booking_type_display }}</dd>
 
             <dt>Travel datetime</dt>
-            <dd>{{ booking.travel_datetime }}</dd>
+            <dd>{{ booking.travel_date }} {{ booking.travel_time }}</dd>
 
             <dt>Vehicle type</dt>
             <dd>{{ booking.vehicle_type }}</dd>


### PR DESCRIPTION
/opencabs/templates/opencabs/booking_details.html, line 32

<dd>{{ booking.travel_datetime }}</dd>   chaged to  
<dd>{{ booking.travel_date }} {{ booking.travel_time }}</dd>

here is a screenshot of booking details after modifications:
![Date time issue](https://user-images.githubusercontent.com/33170360/75135140-976aca80-5706-11ea-8970-1daeeb0487c4.png)
